### PR TITLE
Protect picker_font.dart from null references. Fixes #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+* Fix: Protect null `googleFontsDetails[]` references within `picker_font.dart` when newer GoogleFonts than those used to generate the `constants.dart` are used. Fixes #9.
+
 ## 1.1.2
 
 * Feat: Added `showFontVariants` option to hide font variants in the font picker. If set to false, user will only be able to select the default variant of each font. Closes #7.

--- a/lib/src/models/picker_font.dart
+++ b/lib/src/models/picker_font.dart
@@ -23,11 +23,14 @@ class PickerFont {
     this.fontStyle = FontStyle.normal,
     this.isRecent = false,
   })  : variants = parseVariants(fontFamily),
-        subsets = googleFontsDetails[fontFamily]!["subsets"]!.split(","),
-        category = googleFontsDetails[fontFamily]!["category"]!;
+        subsets = googleFontsDetails[fontFamily]!=null ? googleFontsDetails[fontFamily]!["subsets"]!.split(",") :
+                        <String>[],
+        category = googleFontsDetails[fontFamily]!=null ? googleFontsDetails[fontFamily]!["category"]!
+                      : 'serif';
 
   static List<String> parseVariants(String fontFamily) {
-    var variants = googleFontsDetails[fontFamily]!["variants"]!.split(",");
+    var variants = googleFontsDetails[fontFamily]!=null ? googleFontsDetails[fontFamily]!["variants"]!.split(",")
+                      : <String>[];
     if (variants.any((v) => v.contains("i"))) {
       variants.add("italic");
     }


### PR DESCRIPTION
This fixes #9 by including sensible defaults when no information is present about a font within the `googleFontsDetails[]` map.

(Note the choice of `serif` as the default category is arbitrary and could as well be `san-serif`, etc.)
 I simply chose the first element of the `googleFontCategories` list.