### PR TITLE
Enhancement: Add font size control,list preview text, more robust example\main.dart... 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.5
+
+* Feat: The `example\main.dart` example program has been enhanced to include a control panel that allows all possible options to `FontPicker()` to be played with and adjusted.  It also now includes a `useDevicePreview` constant that can be set to true to enable previewing `FontPicker()`'s behavior on a wide variety of possible flutter platforms, screensizes and device orientations.
+* Feat:  Added ability to set font sizes and list preview text. 
+   - `previewSampleTextFontSize` - Font size used for preview sample text above list.
+    - `fontSizeForListPreview`: Font size to use for each font name within font picker list.  (Optional list preview sample text also uses this size). Defaults to 14 (previously hardcoded).
+    - `showListPreviewSampleTextInput` - Set whether to include form field to allow user to change the list preview sample text.
+    - `listPreviewSampleText` - Optional sample text include to right of each font within picker list.
+
 ## 1.1.3
 
 * Fix: Protect null `googleFontsDetails[]` references within `picker_font.dart` when newer GoogleFonts than those used to generate the `constants.dart` are used. Fixes #9.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Provides a `FontPicker` widget that can be used in a route or dialog as a UI for
 
 Depends on the [google_fonts](https://pub.dev/packages/google_fonts) package for loading and displaying the fonts.
 
+A 'live' example of the `FontPicker` `example\main.dart` example program, running on the web platform (with additional device preview capabilities enabled) can be found [here](https://timmaffett.github.io/flutter_font_picker/).
+
 Localizations available for 🇪🇸🇩🇪🇮🇹🇵🇹🇫🇷🇵🇱. 
 
 ## Simple Example
@@ -63,6 +65,10 @@ Check the example project for more usages.
 - `showFontVariants`: Whether to show font variants (weights and styles) in the font picker. If set to false, user will only be able to select the default variant of each font.
 - `showInDialog`: Set this to true if you want to use the font picker inside an AlertDialog (check examples).
 - `recentsCount`: Fonts that the user selected before are saved to be shown at the start of the list. Sets how many you want saved as recents.
+- `previewSampleTextFontSize` - Font size used for preview sample text above list.
+- `fontSizeForListPreview`: Font size to use for each font name within font picker list.  (Optional list preview sample text also uses this size). Defaults to 14.
+- `showListPreviewSampleTextInput` - Set whether to include form field to allow user to change the list preview sample text.
+- `listPreviewSampleText` - Optional sample text include to right of each font within picker list. Defaults to 16.
 - `'lang'`: The language in which to show the UI. Defaults to English (`'en'`). Other options are 🇪🇸🇩🇪🇮🇹🇵🇹🇫🇷🇵🇱 (`'es'`, `'de'`, `'it'`, `'pt'`, `'fr', 'pl'`). If you need a translation in another language: take a look at the `dictionary` variable in `translations.dart`, and send me (or fix) the translations for your language . 
 
 ## FontPicker features

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,6 @@
-# example
+# `main.dart` FontPicker() usage example
 
 An example of using the `FontPicker` widget in different cases.
+All parameters of FontPicker() can be played with and adjusted using the 'FontPicker() configuration settings:' control panel included in the example.
+
+Additionally the `useDevicePreview` constant within `main.dart` can be set to `true` to include ability to preview the FontPicker() control on a variety of possible flutter devices, screensizes and orientations.

--- a/example/lib/flexible.dart
+++ b/example/lib/flexible.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+/// Various options for what to do with the widget that the Row() is being split on.
+enum SplitWidgetBehavior {
+  exclude,
+  includeInThisRow,
+  includeInNextRow,
+}
+
+/// This class exists as a simple way to convert existing Row() widgets into
+/// device size flexible rows which can split into multiple rows when the
+/// device size with is below a certain threshold [splitWidth].
+/// Simply replace your the `Row(` part of your widget call with
+/// `...Splittable.splittableRow(`.
+/// The spread operator ('...') is required because more than a single row can
+/// now be returned if the row is split.
+/// 
+/// [Splittable.splitWidth] can be set to whatever width you would like to 
+/// start splitting rows at, any time the screen width is <= to this 
+/// value the rows will be split.
+/// 
+/// The [splitOn], [splitEveryN], [splitAtIndices], [splitWidgetBehavior]
+/// are defined as needed depending on how you want to split the row on
+/// a narrow screen.
+/// 
+/// Example splitting on a certain widget type in the row and including that
+/// widget on the next row using [SplitWidgetBehavior.includeInNextRow] :
+/// ```
+/// ...Splittable.splittableRow(
+///                context: context,
+///                splitOn: SplitOn<Radio<FontListType>>(),
+///                splitWidgetBehavior:SplitWidgetBehavior.includeInNextRow,
+/// ```
+/// or
+/// splitting the row on every 4th widget and excluding that from the split
+/// rows (for example where there is a horizontal spacer widget not needed
+/// in the split rows):
+/// ```
+/// ...Splittable.splittableRow(
+///                context: context,
+///                splitEveryN: 4,
+///                splitWidgetBehavior:SplitWidgetBehavior.exclude,
+/// ```
+/// or
+/// more complex example were the exact widget indices where the splitting
+/// should take place are specified (and excluding these widgets
+/// with [SplitWidgetBehavior.exclude])
+/// ```
+/// ...Splittable.splittableRow(
+///                context: context,
+///                forceSplit: useExpandPanel || size.width<=850,
+///                splitAtIndices: [ 1 ],
+///                splitWidgetBehavior:SplitWidgetBehavior.exclude,
+///                mainAxisAlignment: mainAxisAlignment,
+///
+class Splittable {
+  static int splitWidth = 500;
+
+  static bool willSplitRows(BuildContext context) {
+    Size size = MediaQuery.of(context).size;                            
+    return size.width<=splitWidth;
+  }
+
+  /// [splitAtIndices] supply an array of the index numbers of split widgets
+  /// [splitEveryN] supply if you want to split on every Nth widget.
+  /// [splitWidgetBehavior] what to do with the split widget SplitWidgetBehavior.(exclude, includeInThisRow or includeInNextRow)
+  /// [splitOn] SplitOn instance which holds type of widget to split on, ie. SplitOn<SizedBox>
+  static List<Widget> splittableRow( { 
+                          required BuildContext context,
+                          required List<Widget>children,
+                          Type? splitOn,
+                          int? splitEveryN,
+                          List<int>? splitAtIndices,
+                          SplitWidgetBehavior splitWidgetBehavior = SplitWidgetBehavior.exclude,
+                          bool forceSplit=false,
+                          // the following are the standard Row() arguments we pass on
+                          MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
+                          MainAxisSize mainAxisSize = MainAxisSize.max,
+                          CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
+                          TextDirection? textDirection,
+                          VerticalDirection verticalDirection = VerticalDirection.down,
+                          TextBaseline? textBaseline,
+                        } ) {
+    assert( splitOn!=null || splitEveryN!=null || splitAtIndices!=null, 'Must supply either splitOn<T>, splitEveryN or splitAtIndices');
+    bool splitting = willSplitRows(context) || forceSplit;
+
+    // if now splitting the row then just return a Row() widget with all these children
+    if(!splitting) {
+      return [ Row( mainAxisAlignment:mainAxisAlignment,
+                                    mainAxisSize:mainAxisSize,crossAxisAlignment:crossAxisAlignment,
+                                    textDirection:textDirection,verticalDirection:verticalDirection,
+                                    textBaseline:textBaseline,
+                                    children: children,
+                    ),
+              ];
+    }
+    List<Widget> curRowWidgets = [];
+    List<Widget> splitRows = [];
+    for(int i=0;i<children.length;i++) {
+      final item = children[i];
+      if( (splitOn!=null && item.runtimeType==splitOn) ||
+            (splitEveryN!=null && (i+1)%splitEveryN==0) ||
+            (splitAtIndices!=null && splitAtIndices.contains(i)) ) {
+        // splitting here
+        if(splitWidgetBehavior==SplitWidgetBehavior.includeInThisRow) curRowWidgets.add(item);
+        splitRows.add( Row( mainAxisAlignment:mainAxisAlignment,
+                                    mainAxisSize:mainAxisSize,crossAxisAlignment:crossAxisAlignment,
+                                    textDirection:textDirection,verticalDirection:verticalDirection,
+                                    textBaseline:textBaseline,
+                                    children: [ ...curRowWidgets ],
+                    ) );
+        curRowWidgets.clear();
+        if(splitWidgetBehavior==SplitWidgetBehavior.includeInNextRow) curRowWidgets.add(item);
+      } else {
+        curRowWidgets.add(item);
+      }
+    }
+    if(curRowWidgets.isNotEmpty) {
+      splitRows.add( Row( mainAxisAlignment:mainAxisAlignment,
+                                    mainAxisSize:mainAxisSize,crossAxisAlignment:crossAxisAlignment,
+                                    textDirection:textDirection,verticalDirection:verticalDirection,
+                                    textBaseline:textBaseline,
+                                    children: [ ...curRowWidgets ],
+                    ) );
+    }
+    return splitRows;
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_font_picker/flutter_font_picker.dart';
+// ignore: depend_on_referenced_packages
+import 'package:google_fonts/google_fonts.dart';
+
+import 'package:device_preview/device_preview.dart'; // required when useDevicePreview==true
+import 'flexible.dart';
+
+/// Set [useDevicePreview] to allow testing layouts on virtual device screens
+const useDevicePreview = false;
 
 void main() {
-  runApp(const MyApp());
+  if(useDevicePreview) {
+    //TEST various on various device screens//
+    runApp(DevicePreview(
+            builder: (context) => const MyApp(), // Wrap your app
+            enabled: true,
+          ));
+  } else {
+    runApp(const MyApp());
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -29,10 +45,33 @@ class MyHomePage extends StatefulWidget {
   _MyHomePageState createState() => _MyHomePageState();
 }
 
+enum FontListType { subset, complete }
 class _MyHomePageState extends State<MyHomePage> {
-  String _selectedFont = "Roboto";
-  TextStyle? _selectedFontTextStyle;
-  final List<String> _myGoogleFonts = [
+  String _selectedFont = 'Roboto';
+
+  late TextStyle? _selectedFontTextStyle = GoogleFonts.getFont(_selectedFont);
+
+  bool _showFontVariants = true;
+
+  bool _showFontInfo = true;
+
+  bool _showListPreviewSampleTextInput = false;
+
+  String _listPreviewSampleText = '';
+
+  double _sampleTextFontSize = 14.0;
+
+  double _fontPickerListFontSize = 16.0;
+
+  double _previewFontSize = 24.0;
+
+  FontListType _fontListType = FontListType.subset;
+
+  late List<String> _myGoogleFonts = _subsetListOfGoogleFonts;
+
+  final List<String> _completeGoogleFonts = GoogleFonts.asMap().keys.toList();
+
+  final List<String> _subsetListOfGoogleFonts = [
     "Abril Fatface",
     "Aclonica",
     "Alegreya Sans",
@@ -63,6 +102,7 @@ class _MyHomePageState extends State<MyHomePage> {
     "Merriweather",
     "Montserrat",
     "Mukta",
+    "Nabla",
     "Nunito",
     "Offside",
     "Open Sans",
@@ -86,100 +126,311 @@ class _MyHomePageState extends State<MyHomePage> {
     "Work Sans",
     "Zilla Slab",
   ];
+
+  void _onFontListTypeChange( FontListType? val ) {
+    setState(() {
+      _fontListType = val ?? FontListType.subset;
+      if(_fontListType == FontListType.subset) {
+        _myGoogleFonts = _subsetListOfGoogleFonts;
+      } else {
+        _myGoogleFonts = _completeGoogleFonts;
+      }
+    });
+  }
+
+  bool? configPanelExpanded;
+
+  List<Widget> buildFlexibleOptionsCustomizationPanel(BuildContext context) {
+    final size = MediaQuery.of(context).size; 
+    var willSplitRows = Splittable.willSplitRows(context);
+    final bool useExpandPanel = willSplitRows || (size.height<400);
+    // if we are going to use the expand panel because short then FORCE split
+    if(useExpandPanel && !willSplitRows) willSplitRows = true;
+
+    // we set the initial value of configPanelExpanded depending on
+    // how we initially have to render it.  If we don't initially have
+    // to split the rows then we will init it to 'expanded', that way if the
+    // window shrinks and we are forced to use it it will already be expanded,
+    // (as it is when it is NOT rendered in a panel)
+    configPanelExpanded ??= !useExpandPanel;
+
+    final mainAxisAlignment = willSplitRows ? MainAxisAlignment.start 
+                                      : MainAxisAlignment.center;
+    final controlPanelItems = <Widget>[
+              ...Splittable.splittableRow(
+                context: context,
+                splitOn: Radio<FontListType>,
+                splitWidgetBehavior:SplitWidgetBehavior.includeInNextRow,
+                mainAxisAlignment: mainAxisAlignment,
+                children: <Widget>[
+                  const Text(
+                    'List of fonts is :',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  Radio<FontListType>(
+                    value: FontListType.subset,
+                    groupValue: _fontListType,
+                    onChanged: _onFontListTypeChange,
+                  ),
+                  const Text(
+                    'Subset of GoogleFonts',
+                    style: TextStyle(fontSize: 16.0),
+                  ),
+                  Radio<FontListType>(
+                    value: FontListType.complete,
+                    groupValue: _fontListType,
+                    onChanged: _onFontListTypeChange,
+                  ),
+                  const Text(
+                    'All GoogleFonts',
+                    style: TextStyle(
+                      fontSize: 16.0,
+                    ),
+                  ),
+                ],
+              ),
+             ...Splittable.splittableRow(
+                context: context,
+                splitEveryN: 4,
+                splitWidgetBehavior:SplitWidgetBehavior.exclude,
+                mainAxisAlignment: mainAxisAlignment,
+                children: <Widget>[
+                  const Text(
+                    'Show font variants :',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Checkbox(
+                    value: _showFontVariants,
+                    onChanged: (checked) {
+                      setState(() {
+                        _showFontVariants = checked ?? false;
+                      });
+                    },
+                  ),
+                  const SizedBox(width: 30),
+                  const Text(
+                    'Show font info :',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Checkbox(
+                    value: _showFontInfo,
+                    onChanged: (checked) {
+                      setState(() {
+                        _showFontInfo = checked ?? false;
+                      });
+                    },
+                  ),
+                ],
+              ),
+             ...Splittable.splittableRow(
+                context: context,
+                forceSplit: useExpandPanel || size.width<=850,
+                splitAtIndices: [ 1 ],
+                splitWidgetBehavior:SplitWidgetBehavior.exclude,
+                mainAxisAlignment: mainAxisAlignment,
+                children: <Widget>[
+                  ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: !useExpandPanel ? 300 : size.width*0.8,
+                    ),
+                    child: FontListPreviewSample(
+                      onSampleTextChanged: (newSample) {
+                        setState(() {
+                          _listPreviewSampleText = newSample;
+                        });
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 30),
+                  const Text(
+                    'Editing of list preview sample text :',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Checkbox(
+                    value: _showListPreviewSampleTextInput,
+                    onChanged: (checked) {
+                      setState(() {
+                        _showListPreviewSampleTextInput = checked ?? false;
+                      });
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height:10),
+              ...Splittable.splittableRow(
+                context: context,
+                splitOn: Slider,
+                splitWidgetBehavior:SplitWidgetBehavior.includeInNextRow,
+                mainAxisAlignment: mainAxisAlignment,
+                children: <Widget>[
+                  Text(
+                    'Font size for sample text : ${_sampleTextFontSize}px',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  Slider(
+                    min: 10.0,
+                    max: 64.0,
+                    value: _sampleTextFontSize,
+                    onChanged: (value) {
+                      setState(() {
+                        _sampleTextFontSize = value.round().toDouble();
+                      });
+                    },
+                  ),
+                ],
+              ),
+              ...Splittable.splittableRow(
+                context: context,
+                splitOn: Slider,
+                splitWidgetBehavior:SplitWidgetBehavior.includeInNextRow,
+                mainAxisAlignment: mainAxisAlignment,
+                children: <Widget>[
+                  Text(
+                    'Font size for fonts in picker list : ${_fontPickerListFontSize}px',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  Slider(
+                    min: 10.0,
+                    max: 64.0,
+                    value: _fontPickerListFontSize,
+                    onChanged: (value) {
+                      setState(() {
+                        _fontPickerListFontSize = value.round().toDouble();
+                      });
+                    },
+                  ),
+                ],
+              ),
+              if(!willSplitRows) Padding(
+                        padding: const EdgeInsets.all(12.0),
+                        child:Container( height: 2, color: Colors.black ),
+                      ),
+    ];
+
+    final controlPanelColumn = Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: <Widget>[
+                    ...controlPanelItems,
+                  ],
+                );
+
+    // Return either the control panel widgets directly or place them in a 
+    // ExpansionPanelList/ExpansionPanel.
+    return [
+      if(!useExpandPanel) ...[
+            const SizedBox(height: 12),
+            const Text(
+              'Optional settings to configure FontPicker() :',
+              style: TextStyle(
+                color: Colors.black,
+                fontWeight: FontWeight.bold,
+                fontSize: 16.0,
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+      !useExpandPanel ?
+        controlPanelColumn
+      : ExpansionPanelList(
+        animationDuration: const Duration(milliseconds:500),
+        expandIconColor: Colors.green,
+        expandedHeaderPadding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
+        elevation:1,
+        children: [
+            ExpansionPanel(
+              backgroundColor: const Color.fromARGB(255,220,220,220),
+              body: Container(
+                padding: const EdgeInsets.fromLTRB(20, 8, 10, 0),
+                child: controlPanelColumn,
+              ),
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return Container(
+                    color: Colors.teal,
+                    padding: const EdgeInsets.fromLTRB(20.0, 14.0, 6.0, 0),
+                    child: const Text('FontPicker() configuration settings : ',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14.0,
+                      ),
+                    ),
+                  );
+              },
+              isExpanded: configPanelExpanded!,
+              canTapOnHeader : true,
+          ),
+          ],
+        expansionCallback: (int item, bool status) {
+          setState(() {
+            configPanelExpanded = !configPanelExpanded!;
+          });
+        },
+      ),
+      const SizedBox(height: 12),
+   ];
+  }
+
+
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;   
+
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ElevatedButton(
-                child: const Text('Pick a font (with a screen)'),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => FontPicker(
-                        recentsCount: 10,
-                        onFontChanged: (font) {
-                          setState(() {
-                            _selectedFont = font.fontFamily;
-                            _selectedFontTextStyle = font.toTextStyle();
-                          });
-                          debugPrint(
-                            "${font.fontFamily} with font weight ${font.fontWeight} and font style ${font.fontStyle}. FontSpec: ${font.toFontSpec()}",
-                          );
-                        },
-                        googleFonts: _myGoogleFonts,
+      body: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints viewportConstraints) {
+          return ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: viewportConstraints.maxHeight,
+            ),
+            child: IntrinsicHeight(child: Padding(
+              padding: const EdgeInsets.fromLTRB(12.0, 5.0, 12.0, 5.0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ...buildFlexibleOptionsCustomizationPanel(context),
+                    const Text(
+                      'Examples of FontPicker() (using above settings):',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16.0,
                       ),
                     ),
-                  );
-                },
-              ),
-              ElevatedButton(
-                child: const Text('Pick a font (with a dialog)'),
-                onPressed: () {
-                  showDialog(
-                    context: context,
-                    builder: (context) {
-                      return AlertDialog(
-                        content: SingleChildScrollView(
-                          child: SizedBox(
-                            width: double.maxFinite,
-                            child: FontPicker(
-                              showInDialog: true,
-                              initialFontFamily: 'Anton',
-                              onFontChanged: (font) {
-                                setState(() {
-                                  _selectedFont = font.fontFamily;
-                                  _selectedFontTextStyle = font.toTextStyle();
-                                });
-                                debugPrint(
-                                  "${font.fontFamily} with font weight ${font.fontWeight} and font style ${font.fontStyle}. FontSpec: ${font.toFontSpec()}",
-                                );
-                              },
-                              googleFonts: _myGoogleFonts,
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  );
-                },
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Expanded(
-                    child: Padding(
-                      padding: EdgeInsets.all(8.0),
-                      child: Text(
-                        'Pick a font: ',
-                        textAlign: TextAlign.right,
-                        style: TextStyle(fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: TextField(
-                      readOnly: true,
-                      textAlign: TextAlign.center,
-                      decoration: InputDecoration(
-                        suffixIcon: const Icon(Icons.arrow_drop_down_sharp),
-                        hintText: _selectedFont,
-                        border: InputBorder.none,
-                      ),
-                      onTap: () {
+                    const SizedBox(height: 12),
+                    ElevatedButton(
+                      child: const Text('Pick a font (with a screen)'),
+                      onPressed: () {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
                             builder: (context) => FontPicker(
+                              recentsCount: 10,
                               onFontChanged: (font) {
                                 setState(() {
                                   _selectedFont = font.fontFamily;
@@ -190,51 +441,269 @@ class _MyHomePageState extends State<MyHomePage> {
                                 );
                               },
                               googleFonts: _myGoogleFonts,
+                              showFontVariants: _showFontVariants,
+                              showFontInfo: _showFontInfo,
+                              showListPreviewSampleTextInput: _showListPreviewSampleTextInput,
+                              listPreviewSampleText: _listPreviewSampleText,
+                              previewSampleTextFontSize: _sampleTextFontSize,
+                              fontSizeForListPreview: _fontPickerListFontSize,
+
                             ),
                           ),
                         );
                       },
                     ),
-                  ),
-                ],
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(12.0),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: Colors.blueGrey,
-                        width: 2.0,
+                    const SizedBox(height:16),
+                    ElevatedButton(
+                      child: const Text('Pick a font (with a dialog)'),
+                      onPressed: () {
+                        showDialog(
+                          context: context,
+                          builder: (context) {
+                            return AlertDialog(
+                              content: SingleChildScrollView(
+                                child: SizedBox(
+                                  width: double.maxFinite,
+                                  child: FontPicker(
+                                    showInDialog: true,
+                                    initialFontFamily: 'Anton',
+                                    onFontChanged: (font) {
+                                      setState(() {
+                                        _selectedFont = font.fontFamily;
+                                        _selectedFontTextStyle = font.toTextStyle();
+                                      });
+                                      debugPrint(
+                                        "${font.fontFamily} with font weight ${font.fontWeight} and font style ${font.fontStyle}. FontSpec: ${font.toFontSpec()}",
+                                      );
+                                    },
+                                    googleFonts: _myGoogleFonts,
+                                    showFontVariants: _showFontVariants,
+                                    showFontInfo: _showFontInfo,
+                                    showListPreviewSampleTextInput: _showListPreviewSampleTextInput,
+                                    listPreviewSampleText: _listPreviewSampleText,
+                                    previewSampleTextFontSize: _sampleTextFontSize,
+                                    fontSizeForListPreview: _fontPickerListFontSize,
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+                    ConstrainedBox(
+                      constraints: BoxConstraints(
+                        maxWidth: size.width>500 ? 500 : size.width,
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.all(8.0),
+                              child: Text(
+                                'Pick a font: ',
+                                textAlign: TextAlign.right,
+                                style: TextStyle(fontWeight: FontWeight.w700),
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: TextField(
+                              readOnly: true,
+                              textAlign: TextAlign.center,
+                              style: _selectedFontTextStyle?.copyWith(fontSize:_fontPickerListFontSize),
+                              decoration: InputDecoration(
+                                suffixIcon: const Icon(Icons.arrow_drop_down_sharp),
+                                hintText: _selectedFont,
+                                border: InputBorder.none,
+                              ),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => FontPicker(
+                                      onFontChanged: (font) {
+                                        setState(() {
+                                          _selectedFont = font.fontFamily;
+                                          _selectedFontTextStyle = font.toTextStyle();
+                                        });
+                                        debugPrint(
+                                          "${font.fontFamily} with font weight ${font.fontWeight} and font style ${font.fontStyle}. FontSpec: ${font.toFontSpec()}",
+                                        );
+                                      },
+                                      googleFonts: _myGoogleFonts,
+                                      showFontVariants: _showFontVariants,
+                                      showFontInfo: _showFontInfo,
+                                      showListPreviewSampleTextInput: _showListPreviewSampleTextInput,
+                                      listPreviewSampleText: _listPreviewSampleText,
+                                      previewSampleTextFontSize: _sampleTextFontSize,
+                                      fontSizeForListPreview: _fontPickerListFontSize,
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    child: Padding(
+                    Padding(
                       padding: const EdgeInsets.all(12.0),
-                      child: Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              'Font: $_selectedFont',
-                              style: _selectedFontTextStyle,
+                      child:Container( height: 2, color: Colors.black ),
+                    ),
+                    ...Splittable.splittableRow(
+                      context: context,
+                      splitOn: Slider,
+                      splitWidgetBehavior:SplitWidgetBehavior.includeInNextRow,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Text(
+                          'Preview font size : ${_previewFontSize}px',
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16.0,
+                          ),
+                        ),
+                        Slider(
+                          min: 10.0,
+                          max: 96.0,
+                          value: _previewFontSize,
+                          onChanged: (value) {
+                            setState(() {
+                              _previewFontSize = value.round().toDouble();
+                            });
+                          },
+                        ),
+                      ],
+                    ),
+                    ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: viewportConstraints.minHeight,
+                        maxHeight: viewportConstraints.maxHeight,
+                      ),
+                      child: IntrinsicHeight(child:
+                        Padding(
+                          padding: const EdgeInsets.all(12.0),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: Colors.blueGrey,
+                                width: 2.0,
+                              ),
                             ),
-                            Text(
-                              'The quick brown fox jumped',
-                              style: _selectedFontTextStyle,
+                            child: Padding(
+                              padding: const EdgeInsets.all(12.0),
+                              child: ClipRect(
+                                clipBehavior: Clip.hardEdge,
+                                child: OverflowBox(
+                                  alignment: Alignment.center,
+                                  minWidth: 0.0,
+                                  minHeight: viewportConstraints.minHeight,
+                                  maxWidth: double.infinity,
+                                  maxHeight: viewportConstraints.maxHeight,//double.infinity,   
+                                  child: Column(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        'Font: $_selectedFont',
+                                        style: _selectedFontTextStyle?.copyWith(fontSize:_previewFontSize),
+                                        textAlign: TextAlign.center,
+                                      ),
+                                      Text(
+                                        'The quick brown fox jumped',
+                                        style: _selectedFontTextStyle?.copyWith(fontSize:_previewFontSize),
+                                        textAlign: TextAlign.center,
+                                      ),
+                                      Text(
+                                        'over the lazy dog',
+                                        style: _selectedFontTextStyle?.copyWith(fontSize:_previewFontSize),
+                                        textAlign: TextAlign.center,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
                             ),
-                            Text(
-                              'over the lazy dog',
-                              style: _selectedFontTextStyle,
-                            ),
-                          ],
+                          ),
                         ),
                       ),
                     ),
-                  ),
+                  ],
                 ),
               ),
-            ],
+            ),),
+          );
+        },
+      ),
+    );
+  }
+}
+
+
+
+class FontListPreviewSample extends StatefulWidget {
+  const FontListPreviewSample({super.key, this.initialSampleText = '', required this.onSampleTextChanged});
+
+  final String initialSampleText;
+  final ValueChanged<String> onSampleTextChanged;
+
+  @override
+  _FontListPreviewSampleState createState() => _FontListPreviewSampleState();
+}
+
+class _FontListPreviewSampleState extends State<FontListPreviewSample> {
+  bool _isSampleFocused = false;
+  late final TextEditingController sampleController;
+
+  @override
+  void initState() {
+    super.initState();
+    sampleController = TextEditingController(text:widget.initialSampleText);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusScope(
+      child: Focus(
+        onFocusChange: (focus) {
+          setState(() {
+            _isSampleFocused = focus;
+          });
+        },
+        child: TextFormField(
+          controller: sampleController,
+          decoration: InputDecoration(
+            prefixIcon: const Icon(
+              Icons.list,
+            ),
+            label:  const Text(
+                    'List preview sample text',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.0,
+                    ),
+                  ),
+            suffixIcon: _isSampleFocused
+                ? IconButton(
+                    icon: const Icon(Icons.cancel),
+                    onPressed: () {
+                      FocusScope.of(context).unfocus();
+                      sampleController.clear();
+                      widget.onSampleTextChanged('');
+                    },
+                  )
+                : null,
+            hintText: 'Optional sample text to add to each font preview in list',
+            hintStyle: const TextStyle(fontSize: 14.0),
+            border: InputBorder.none,
+            focusedBorder: InputBorder.none,
+            enabledBorder: InputBorder.none,
+            errorBorder: InputBorder.none,
+            disabledBorder: InputBorder.none,
           ),
+          onChanged: widget.onSampleTextChanged,
         ),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -129,6 +129,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
+  device_frame:
+    dependency: transitive
+    description:
+      name: device_frame
+      sha256: afe76182aec178d171953d9b4a50a43c57c7cf3c77d8b09a48bf30c8fa04dd9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  device_preview:
+    dependency: "direct main"
+    description:
+      name: device_preview
+      sha256: "2f097bf31b929e15e6756dbe0ec1bcb63952ab9ed51c25dc5a2c722d2b21fdaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -164,7 +180,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.3"
+    version: "1.1.5"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -173,6 +189,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -183,6 +204,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   glob:
     dependency: transitive
     description:
@@ -195,10 +224,10 @@ packages:
     dependency: transitive
     description:
       name: google_fonts
-      sha256: "8f099045e2f2a30e4d4d0a35f40c6bc941a8f2ca0e10ad9d214ee9edd3f37483"
+      sha256: "927573f2e8a8d65c17931e21918ad0ab0666b1b636537de7c4932bdb487b190f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.3"
   html:
     dependency: transitive
     description:
@@ -223,14 +252,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.0"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -251,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
@@ -267,10 +304,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -283,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: transitive
     description:
@@ -367,6 +412,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -488,10 +541,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -549,5 +602,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
   flutter_font_picker:
     path: ../
-
+  device_preview: 1.1.0    # required only for virtual device screen testing
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -1,17 +1,4 @@
-import 'package:flutter/material.dart';
-
 const prefsRecentsKey = "font_picker_recents";
-const fontWeightValues = {
-  "100": FontWeight.w100,
-  "200": FontWeight.w200,
-  "300": FontWeight.w300,
-  "400": FontWeight.w400,
-  "500": FontWeight.w500,
-  "600": FontWeight.w600,
-  "700": FontWeight.w700,
-  "800": FontWeight.w800,
-  "900": FontWeight.w900,
-};
 
 const googleFontCategories = [
   'serif',

--- a/lib/src/constants/fontweights_map.dart
+++ b/lib/src/constants/fontweights_map.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+const fontWeightValues = {
+  "100": FontWeight.w100,
+  "200": FontWeight.w200,
+  "300": FontWeight.w300,
+  "400": FontWeight.w400,
+  "500": FontWeight.w500,
+  "600": FontWeight.w600,
+  "700": FontWeight.w700,
+  "800": FontWeight.w800,
+  "900": FontWeight.w900,
+};

--- a/lib/src/constants/translations.dart
+++ b/lib/src/constants/translations.dart
@@ -39,6 +39,7 @@ const dictionary = {
     'display': 'display',
     'handwriting': 'handwriting',
     'monospace': 'monospace',
+    'List preview sample text': 'List preview sample text',
   },
   "es": {
     'search': 'Buscar...',
@@ -80,6 +81,7 @@ const dictionary = {
     'display': 'mostrar',
     'handwriting': 'escritura',
     'monospace': 'monoespacio',
+    'List preview sample text': 'Texto de ejemplo de vista previa de lista',
   },
   "de": {
     'search': 'Suche...',
@@ -121,6 +123,7 @@ const dictionary = {
     'display': 'anzeige',
     'handwriting': 'handschrift',
     'monospace': 'monospace',
+    'List preview sample text': 'Listenvorschau-Beispieltext',
   },
   "fr": {
     'search': 'Chercher...',
@@ -162,6 +165,7 @@ const dictionary = {
     'display': 'affichage',
     'handwriting': 'écriture',
     'monospace': 'monospace',
+    'List preview sample text': "Répertorier l'exemple de texte d'aperçu",
   },
   "it": {
     'search': 'Ricerca...',
@@ -203,6 +207,7 @@ const dictionary = {
     'display': 'visualizzazione',
     'handwriting': 'grafia',
     'monospace': 'monospazio',
+    'List preview sample text': "Testo di esempio dell'anteprima dell'elenco",
   },
   "pt": {
     'search': 'Procurar...',
@@ -244,6 +249,7 @@ const dictionary = {
     'display': 'exibição',
     'handwriting': 'caligrafia',
     'monospace': 'monoespaço',
+    'List preview sample text': 'Texto de amostra de visualização da lista',
   },
   "pl": {
     'search': 'Szukaj...',
@@ -285,6 +291,7 @@ const dictionary = {
     'display': 'plakatowe',
     'handwriting': 'ręcznie pisane',
     'monospace': 'monospace',
+    'List preview sample text': "Przykładowy tekst podglądu listy",
   },
 };
 

--- a/lib/src/models/picker_font.dart
+++ b/lib/src/models/picker_font.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../constants/constants.dart';
+import '../constants/fontweights_map.dart';
 
 /// A wrapper class that contains details about each font in the [FontPicker].
 ///

--- a/lib/src/ui/font_picker.dart
+++ b/lib/src/ui/font_picker.dart
@@ -73,6 +73,18 @@ class FontPicker extends StatefulWidget {
   /// If you need a translation in another language: take a look at the dictionaries variable in constants.dart, and send me the translations for your language.
   final String lang;
 
+  /// Set whether to include form field to allow user to change the list preview sample text.
+  final bool showListPreviewSampleTextInput;
+
+  /// Optional sample text include to right of each font within picker list.
+  final String? listPreviewSampleText;
+
+  /// Font size to use for each font name within font picker list.  (Optional list preview sample text also uses this size).
+  final double fontSizeForListPreview;
+
+  /// Font size used for preview sample text above list.
+  final double previewSampleTextFontSize;
+
   /// Creates a widget that lets the user select a Google font from a provided list.
   ///
   /// The [onFontChanged] function retrieves the font that the user selects with an object containing details like the font's name, weight, style, etc.
@@ -88,6 +100,10 @@ class FontPicker extends StatefulWidget {
     required this.onFontChanged,
     this.initialFontFamily,
     this.lang = "en",
+    this.showListPreviewSampleTextInput = false,
+    this.listPreviewSampleText,
+    this.fontSizeForListPreview = 16.0,
+    this.previewSampleTextFontSize = 14.0,
   });
 
   @override
@@ -113,6 +129,10 @@ class _FontPickerState extends State<FontPicker> {
             initialFontFamily: widget.initialFontFamily ?? 'Roboto',
             lang: widget.lang,
             showFontVariants: widget.showFontVariants,
+            showListPreviewSampleTextInput: widget.showListPreviewSampleTextInput,
+            listPreviewSampleText: widget.listPreviewSampleText,
+            fontSizeForListPreview: widget.fontSizeForListPreview,
+            previewSampleTextFontSize: widget.previewSampleTextFontSize,
           )
         : Scaffold(
             appBar: AppBar(title: const Text("Pick a font:")),
@@ -125,6 +145,10 @@ class _FontPickerState extends State<FontPicker> {
               initialFontFamily: widget.initialFontFamily ?? 'Roboto',
               lang: widget.lang,
               showFontVariants: widget.showFontVariants,
+              showListPreviewSampleTextInput: widget.showListPreviewSampleTextInput,
+              listPreviewSampleText: widget.listPreviewSampleText,
+              fontSizeForListPreview: widget.fontSizeForListPreview,
+              previewSampleTextFontSize: widget.previewSampleTextFontSize,
             ),
           );
   }

--- a/lib/src/ui/font_preview.dart
+++ b/lib/src/ui/font_preview.dart
@@ -6,11 +6,13 @@ class FontPreview extends StatelessWidget {
   final String fontFamily;
   final FontWeight fontWeight;
   final FontStyle fontStyle;
+  final double fontSize;
   const FontPreview({
     super.key,
     required this.fontFamily,
     required this.fontWeight,
     required this.fontStyle,
+    required this.fontSize,
   });
 
   @override
@@ -21,13 +23,14 @@ class FontPreview extends StatelessWidget {
         textAlign: TextAlign.center,
         style: GoogleFonts.getFont(
           fontFamily,
+          fontSize: fontSize,
           fontWeight: fontWeight,
           fontStyle: fontStyle,
         ),
         decoration: InputDecoration(
           hintText: translations.d['sampleText'],
           hintStyle: TextStyle(
-            fontSize: 14.0,
+            fontSize: fontSize,
             fontStyle: fontStyle,
             fontWeight: fontWeight,
           ),

--- a/lib/src/ui/font_sample.dart
+++ b/lib/src/ui/font_sample.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../constants/translations.dart';
+
+class FontSample extends StatefulWidget {
+  final String initialSampleText;
+  final ValueChanged<String> onSampleTextChanged;
+  const FontSample({super.key, this.initialSampleText = '', required this.onSampleTextChanged});
+
+  @override
+  _FontSampleState createState() => _FontSampleState();
+}
+
+class _FontSampleState extends State<FontSample> {
+  bool _isSampleFocused = false;
+  late final TextEditingController sampleController;
+
+  @override
+  void initState() {
+    super.initState();
+    sampleController = TextEditingController(text:widget.initialSampleText);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusScope(
+      child: Focus(
+        onFocusChange: (focus) {
+          setState(() {
+            _isSampleFocused = focus;
+          });
+        },
+        child: TextFormField(
+          controller: sampleController,
+          decoration: InputDecoration(
+            prefixIcon: const Icon(
+              Icons.list,
+            ),
+            suffixIcon: _isSampleFocused
+                ? IconButton(
+                    icon: const Icon(Icons.cancel),
+                    onPressed: () {
+                      FocusScope.of(context).unfocus();
+                      sampleController.clear();
+                      widget.onSampleTextChanged('');
+                    },
+                  )
+                : null,
+            hintText: translations.d['List preview sample text'],
+            hintStyle: const TextStyle(fontSize: 14.0),
+            border: InputBorder.none,
+            focusedBorder: InputBorder.none,
+            enabledBorder: InputBorder.none,
+            errorBorder: InputBorder.none,
+            disabledBorder: InputBorder.none,
+          ),
+          onChanged: widget.onSampleTextChanged,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_font_picker
 description: A Flutter widget that lets the user select a Google Font from a custom dropdown/screen.
-version: 1.1.3
+version: 1.1.5
 homepage: https://github.com/whiplashoo/flutter_font_picker
 
 environment:
@@ -10,15 +10,18 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_fonts: ^3.0.1
+  google_fonts: ^4.0.3
   shared_preferences: ^2.0.3
+
+  
 
 dev_dependencies:
   flutter_lints: ^2.0.1
   dart_code_metrics: ^4.15.2
   flutter_test:
     sdk: flutter
-
+  args: ^2.4.0
+  
 flutter:
 
 


### PR DESCRIPTION
…allowing tinkering and previewing of all capabilities, and optional device preview also included.

This PR includes a few (optional) enhancements to allow control of font sizes in preview text and font list display, as well as the capability to optionally enable preview text within the font list.

The `example/main.dart` has been enhanced to include a control panel that allows previewing and tinkering with all of the possible settings.  Additionally it now includes a 'useDevicePreview' constant that can be set to true to enable previewing `FontPicker` on a wide variety of possible flutter devices, screen sizes and orientations.

A 'live' web preview of this PR (with device preview enabled) can be found at [https://timmaffett.github.io/flutter_font_picker/](https://timmaffett.github.io/flutter_font_picker/).  (The device preview capabilities are provided via the wonderful [https://pub.dev/packages/device_preview package](https://pub.dev/packages/device_preview package) )

All of the changes are compatible, flexible and reactive to various screen sizes and orientations (as were all the previous FontPicker() capabilities).

Initially I needed to make the font sizes a little larger to aid in choosing fonts, but then this expanded to the other features when I additionally determined that adding list preview text would greatly make my user's lives easier by allowing them to see preview text directly in the font picker list without having to individually select each font in turn.

The `readme.md` file now includes a link to the live example on my github.io, but please feel free to compile your own example and put it on your github.io, (or continue using the example on mine), or remove the live example link entirely.
I personally find live examples very useful when I am previewing packages, and with the additional device previewing it allows users to better see how it will work great for them in different use cases..